### PR TITLE
$ missing in line 113 for {SFTP_KEY_FILE} var

### DIFF
--- a/template/Template_SFTP_Check.xml
+++ b/template/Template_SFTP_Check.xml
@@ -110,7 +110,7 @@
                     <type>10</type>
                     <snmp_community/>
                     <snmp_oid/>
-                    <key>sftpCheck.sh[&quot;{$SFTP_HOST}&quot;,&quot;{$SFTP_USER}&quot;,&quot;{SFTP_KEY_FILE}&quot;,&quot;{$SFTP_KEY_PASS}&quot;,&quot;{HOST.HOST}&quot;]</key>
+                    <key>sftpCheck.sh[&quot;{$SFTP_HOST}&quot;,&quot;{$SFTP_USER}&quot;,&quot;{$SFTP_KEY_FILE}&quot;,&quot;{$SFTP_KEY_PASS}&quot;,&quot;{HOST.HOST}&quot;]</key>
                     <delay>1m</delay>
                     <history>30d</history>
                     <trends>365d</trends>


### PR DESCRIPTION
<key>sftpCheck.sh[&quot;{$SFTP_HOST}&quot;,&quot;{$SFTP_USER}&quot;,&quot;{$SFTP_KEY_FILE}&quot;,&quot;{$SFTP_KEY_PASS}&quot;,&quot;{HOST.HOST}&quot;]</key>